### PR TITLE
Fix/loc lay map aud statemanagement

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,334 +1,83 @@
 # SoundZone - 変更履歴
 
-## [TypeScript Error Fix] - 2025-01-24 - 🔧 TanStack Query v5対応とTypeScriptエラー修正
+## [2025-07-24] Map機能の状態管理移行
 
-### TanStack Query v5への移行対応
-プロジェクトのTypeScriptコンパイルエラーを修正し、TanStack Query v5との互換性を確保しました。
+### 概要
+map機能をStateManagement.mdの規約に基づいて、Zustand + MMKV + TanStack Query（準備）のアーキテクチャに移行しました。
 
-#### **🚨 発生していたエラー**
+### 追加ファイル
+1. **src/features/map/application/map-store.ts**
+   - UI状態（region、zoomLevel、isFollowingUser）の管理
+   - 設定（mapType、表示オプション）の管理
+   - MMKV による設定の永続化
 
-1. **useQueryのonErrorコールバック削除エラー**
-   ```typescript
-   // エラー内容
-   src/features/auth/presentation/hooks/use-auth.ts:52:5 - error TS2769: 
-   No overload matches this call.
-   Object literal may only specify known properties, 
-   and 'onError' does not exist in type 'UndefinedInitialDataOptions'
+2. **src/features/map/presentation/hooks/useMapSettings.ts**
+   - 地図設定（mapType、コンパス、スケール表示）の管理フック
+
+3. **src/features/map/presentation/hooks/useMapFollowing.ts**
+   - ユーザー位置追従機能の管理フック
+
+4. **src/features/map/presentation/hooks/useMapWithLocation.ts**
+   - locationストアとの連携フック
+   - 位置情報更新時の自動追従機能
+
+5. **src/features/map/application/map-store.test.ts**
+   - Zustandストアのユニットテスト
+
+### 変更ファイル
+1. **src/features/map/presentation/hooks/useMapRegion.ts**
+   - 内部実装をZustandストアに変更（インターフェースは維持）
+
+2. **src/features/map/presentation/components/MapContainer.tsx**
+   - 地図設定をストアから取得するよう変更
+   - ユーザーが地図を操作した際の追従停止機能を追加
+
+3. **src/features/home/presentation/HomeScreen.tsx**
+   - useMapWithLocation フックを使用して位置追従機能を統合
+   - デバッグ用の追従状態表示を追加（開発環境のみ）
+
+### 新機能
+1. **ユーザー位置追従機能**
+   - 現在位置ボタンタップで追従開始
+   - 地図を手動操作すると追従停止
+   - 位置情報更新時に地図が自動的に追従
+
+2. **地図タイプの動的切り替え**
+   - standard / satellite / hybrid の切り替えが可能に
+
+3. **設定の永続化**
+   - 地図タイプ、表示オプションがアプリ再起動後も保持される
+
+### デバッグ機能（開発環境のみ）
+1. **画面表示**
+   - 画面右上に「追従: ON/OFF」の状態表示
+
+2. **コンソールログ**
+   ```
+   [MapStore] 追従モード: ON/OFF
+   [MapWithLocation] 現在位置ボタンタップ: { lat, lng }
+   [MapWithLocation] 位置更新による地図追従: { lat, lng }
+   [MapContainer] 地図手動操作（追従停止）: { lat, lng }
    ```
 
-2. **UseMutationResultのonSuccessプロパティアクセスエラー** 
-   ```typescript
-   // エラー内容
-   src/features/auth/presentation/hooks/use-auth.ts:245:23 - error TS2339: 
-   Property 'onSuccess' does not exist on type 'UseMutationResult<void, Error, void, unknown>'
-   ```
+### テスト方法
+1. **追従機能の確認**
+   - 現在位置ボタンをタップ → 追従ONになることを確認
+   - 地図をドラッグ → 追従OFFになることを確認
+   - 再度現在位置ボタンをタップ → 追従ONに戻ることを確認
 
-3. **暗黙的any型エラー**
-   ```typescript
-   // エラー内容
-   src/features/auth/presentation/hooks/use-auth.ts:52:15 - error TS7006: 
-   Parameter 'error' implicitly has an 'any' type.
-   ```
+2. **永続化の確認**
+   - アプリを完全終了して再起動
+   - 地図設定が保持されていることを確認
 
-4. **位置情報の型エラー**
-   ```typescript
-   // エラー内容  
-   src/features/location/presentation/hooks/useLocation.ts:144:13 - error TS2322: 
-   Type 'number | undefined' is not assignable to type 'number | null'.
-   Type 'undefined' is not assignable to type 'number | null'.
-   ```
-
-#### **🔧 実施した修正**
-
-##### 1. useQueryのエラーハンドリング変更
-**修正前:**
-```typescript
-return useQuery({
-  queryKey: queryKeys.auth.user(),
-  queryFn: async () => {
-    const user = await authService.getCurrentUser();
-    setUser(user);
-    return user;
-  },
-  onError: (error) => {
-    console.error('Failed to fetch current user:', error);
-    setUser(null);
-  },
-});
-```
-
-**修正後:**
-```typescript
-const query = useQuery({
-  queryKey: queryKeys.auth.user(),
-  queryFn: async () => {
-    const user = await authService.getCurrentUser();
-    setUser(user);
-    return user;
-  },
-  staleTime: 5 * 60 * 1000,
-  refetchOnMount: true,
-  refetchOnWindowFocus: false,
-});
-
-// エラーハンドリングはuseEffectで処理
-useEffect(() => {
-  if (query.error) {
-    console.error('Failed to fetch current user:', query.error);
-    setUser(null);
-  }
-}, [query.error, setUser]);
-
-return query;
-```
-
-##### 2. Mutationのエラーハンドリング修正
-**修正前:**
-```typescript
-const signOut = useCallback(async () => {
-  try {
-    await signOutMutation.mutateAsync();
-  } catch (error) {
-    console.error('Sign out error:', error);
-    // サインアウトは失敗してもローカル状態をクリアする
-    signOutMutation.onSuccess?.(); // ❌ onSuccessプロパティは存在しない
-  }
-}, [signOutMutation]);
-```
-
-**修正後:**
-```typescript
-const signOut = useCallback(async () => {
-  try {
-    await signOutMutation.mutateAsync();
-  } catch (error) {
-    console.error('Sign out error:', error);
-    // サインアウトは失敗してもローカル状態をクリアする
-    // フォールバックとして手動でリセット処理を実行
-    reset();
-    queryClient.setQueryData(queryKeys.auth.user(), null);
-    queryClient.removeQueries({ queryKey: queryKeys.auth.all });
-    queryClient.invalidateQueries({ 
-      predicate: (query) => query.queryKey[0] !== 'auth' 
-    });
-  }
-}, [signOutMutation, reset, queryClient]);
-```
-
-##### 3. 位置情報の型安全性向上
-**修正前:**
-```typescript
-if (newLocation.coords.heading === null && currentHeading !== null) {
-  newLocation.coords.heading = currentHeading; // ❌ undefined をnull型に代入
-}
-```
-
-**修正後:**
-```typescript
-if (newLocation.coords.heading === null && currentHeading !== null && currentHeading !== undefined) {
-  newLocation.coords.heading = currentHeading; // ✅ undefinedをチェック
-}
-```
-
-#### **📚 参考ドキュメント**
-- [TanStack Query v5 Migration Guide](https://tanstack.com/query/v5/docs/framework/react/guides/migrating-to-v5)
-- **主要な変更点:**
-  - `onError`、`onSuccess`、`onSettled`が`useQuery`から削除
-  - Mutationの結果オブジェクトから`onSuccess`プロパティが削除
-  - エラーハンドリングは`useEffect`を使用することが推奨
-
-#### **✅ 修正結果**
-- TypeScriptコンパイルエラー: **4件 → 0件**
-- `npx tsc --noEmit`が正常に完了
-- TanStack Query v5との完全互換性を確保
-- 適切なエラーハンドリングパターンの実装
-
-#### **🎯 技術的改善点**
-- **React Hooks Rules準拠**: コールバック内でのHooks呼び出しを回避
-- **型安全性の向上**: undefined/null型の適切な処理
-- **エラーハンドリングの標準化**: useEffectパターンによる一貫性確保
-- **将来性の確保**: TanStack Query最新版への対応完了
-
-### 影響範囲
-- **認証機能**: エラーハンドリングの改善、サインアウト処理の堅牢性向上
-- **位置情報機能**: 型安全性の向上、heading情報の適切な処理
-- **破壊的変更**: なし（既存の機能は正常動作）
-
-## [StateManagement] - 2025-01-24 - 🔄 Layers機能の状態管理移行
-
-### Layers機能のZustand/TanStack Query移行完了
-StateManagement.mdで定義した規約に従い、Layers機能の状態管理をReact標準のuseStateからZustand + TanStack Queryによる構成に移行しました。
-
-#### **📁 新規作成ファイル**
-- **`/src/features/layers/application/layers-store.ts`**: Zustandストアの実装
-  - UI状態（選択レイヤー、ローディング、エラー）の管理
-  - 設定（お気に入り、デフォルトレイヤー）の永続化
-  - immer、persist（MMKV）、devtoolsミドルウェアの適用
-- **`/src/features/layers/infrastructure/layers-service.ts`**: レイヤーデータのAPI/データアクセスサービス
-  - 現在は固定データを返すが、将来的なSupabase連携を想定した設計
-  - ユーザー設定の保存/取得メソッドの実装
-- **`/src/features/layers/presentation/hooks/use-layers-query.ts`**: TanStack Queryフックの実装
-  - レイヤー一覧取得、ユーザー設定管理のクエリ
-  - カスタムレイヤーの作成/更新/削除用ミューテーション
-- **`/src/features/layers/application/__tests__/layers-store.test.ts`**: Zustandストアのユニットテスト
-  - レイヤー選択、お気に入り、設定管理のテスト
-
-#### **🔧 更新ファイル**
-- **`/src/constants/StorageKeys.ts`**: `LAYERS.SETTINGS`キーを追加
-- **`/src/features/layers/presentation/hooks/useLayerSelection.ts`**: 内部実装をZustandストアを使用するように変更
-  - 既存のインターフェースを維持（破壊的変更なし）
-  - TanStack Queryフックを統合
-
-#### **📊 アーキテクチャの改善点**
-- **レイヤー分離**: presentation、application、infrastructure、domain層の明確な責務分離
-- **状態管理の分離**: 
-  - **Ephemeral UI state**: Zustandで管理（selectedLayerIds、isLoading、error）
-  - **Remote server state**: TanStack Queryで管理（availableLayers）
-  - **Persistent client state**: MMKVで永続化（settings、selectedLayerIds）
-
-#### **🎯 主な機能**
-- **レイヤー選択**: 個別レイヤーのトグル、全レイヤーの一括選択/解除、選択状態の永続化
-- **お気に入り機能**: お気に入りレイヤーの管理、設定の永続化
-- **デフォルト設定**: デフォルトレイヤーの設定、初期表示時の自動選択
-
-#### **🔮 将来の拡張性**
-- **Supabase連携**: layers-service.tsでAPIエンドポイントを実装するだけで対応可能
-- **カスタムレイヤー**: 作成/更新/削除のミューテーションフックは実装済み
-- **リアルタイム同期**: Supabase Realtimeとの連携準備完了
-
-#### **⚡ パフォーマンス最適化**
-- shallow比較によるセレクター最適化
-- メモ化によるレンダリング最小化
-- 永続化データの部分保存（partialize）
-
-### 技術的改善点
-- **破壊的変更なし**: 既存のコンポーネントはそのまま動作
-- **型安全性**: TypeScript型チェック完全対応
-- **テストカバレッジ**: ユニットテストの実装
-
-## 概要
-
-layers機能を`StateManagement.md`の規約に従い、React標準のuseStateからZustand + TanStack Queryによる状態管理に移行しました。
-
-## 実装内容
-
-### 1. 作成したファイル
-
-#### 1.1 application層
-- **layers-store.ts**
-  - Zustandストアの実装
-  - UI状態（選択レイヤー、ローディング、エラー）の管理
-  - 設定（お気に入り、デフォルトレイヤー）の永続化
-  - immer、persist（MMKV）、devtoolsミドルウェアの適用
-
-#### 1.2 infrastructure層
-- **layers-service.ts**
-  - レイヤーデータのAPI/データアクセスサービス
-  - 現在は固定データを返すが、将来的なSupabase連携を想定した設計
-  - ユーザー設定の保存/取得メソッドの実装
-
-#### 1.3 presentation層
-- **use-layers-query.ts**
-  - TanStack Queryフックの実装
-  - レイヤー一覧取得、ユーザー設定管理のクエリ
-  - カスタムレイヤーの作成/更新/削除用ミューテーション
-
-#### 1.4 テスト
-- **layers-store.test.ts**
-  - Zustandストアのユニットテスト
-  - レイヤー選択、お気に入り、設定管理のテスト
-
-### 2. 更新したファイル
-
-#### 2.1 StorageKeys.ts
-- `LAYERS.SETTINGS`キーを追加
-
-#### 2.2 useLayerSelection.ts
-- 内部実装をZustandストアを使用するように変更
-- 既存のインターフェースを維持（破壊的変更なし）
-- TanStack Queryフックを統合
-
-### 3. アーキテクチャの改善点
-
-#### 3.1 レイヤー分離
-```
-presentation/
-  ├── hooks/
-  │   ├── useLayerSelection.ts    # UIとの接点
-  │   └── use-layers-query.ts     # サーバー状態管理
-  ├── components/                  # UIコンポーネント（変更なし）
-  └── LayersScreen.tsx            # 画面（変更なし）
-
-application/
-  └── layers-store.ts             # アプリケーション状態管理
-
-infrastructure/
-  └── layers-service.ts           # API/データアクセス
-
-domain/
-  ├── entities/
-  │   └── Layer.ts               # エンティティ定義（変更なし）
-  └── utils/
-      └── layerUtils.ts          # ユーティリティ（変更なし）
-```
-
-#### 3.2 状態管理の分離
-- **Ephemeral UI state**: Zustandで管理（selectedLayerIds、isLoading、error）
-- **Remote server state**: TanStack Queryで管理（availableLayers）
-- **Persistent client state**: MMKVで永続化（settings、selectedLayerIds）
-
-### 4. 主な機能
-
-#### 4.1 レイヤー選択
-- 個別レイヤーのトグル
-- 全レイヤーの一括選択/解除
-- 選択状態の永続化
-
-#### 4.2 お気に入り機能
-- お気に入りレイヤーの管理
-- 設定の永続化
-
-#### 4.3 デフォルト設定
-- デフォルトレイヤーの設定
-- 初期表示時の自動選択
-
-### 5. 将来の拡張性
-
-#### 5.1 Supabase連携
-- layers-service.tsでAPIエンドポイントを実装するだけで対応可能
-- TanStack Queryのキャッシュ戦略は既に実装済み
-
-#### 5.2 カスタムレイヤー
-- 作成/更新/削除のミューテーションフックは実装済み
-- UIの追加のみで機能拡張可能
-
-#### 5.3 リアルタイム同期
-- Supabase Realtimeとの連携準備完了
-- queryClient.invalidateQueriesで更新通知可能
-
-### 6. パフォーマンス最適化
-
-- shallow比較によるセレクター最適化
-- メモ化によるレンダリング最小化
-- 永続化データの部分保存（partialize）
-
-### 7. 破壊的変更
-
-なし。既存のコンポーネントはそのまま動作します。
-
-### 8. 次のステップ
-
-1. 実機での動作確認
-2. Supabase APIとの連携実装（必要に応じて）
-3. カスタムレイヤー機能のUI実装（必要に応じて）
-
-## 関連ドキュメント
-
-- [StateManagement.md](./StateManagement.md) - 状態管理規約
-- [StateManagementMigrationPlan.md](./StateManagementMigrationPlan.md) - 全体の移行計画
-
+### 技術的な改善点
+- グローバル状態管理により、コンポーネント間での状態共有が容易に
+- 設定の永続化により、ユーザー体験が向上
+- locationストアとの適切な連携により、機能間の結合度が低減
+- テスタビリティの向上（ユニットテスト実装）
 
 ### 次のステップ
-実機での動作確認、Supabase APIとの連携実装（必要に応じて）、カスタムレイヤー機能のUI実装（必要に応じて）を計画中。
+- audioPin機能の状態管理移行（Phase 4）
+- 統合テストと最終調整
 
 ---

--- a/docs/LocationTrackingArchitecture.md
+++ b/docs/LocationTrackingArchitecture.md
@@ -1,0 +1,177 @@
+# 位置情報取得と地図更新のアーキテクチャ
+
+## 現在の実装概要
+
+### 1. 位置情報の取得頻度と設定
+
+**位置情報の更新設定（location-store.ts）**
+```typescript
+settings: {
+  locationUpdateInterval: 2000,    // 2秒ごとに位置を更新
+  highAccuracyMode: true,         // 高精度モード使用
+  distanceFilter: 5,              // 5メートル移動で更新
+  headingUpdateInterval: 100,     // 100ミリ秒ごとに方向を更新
+}
+```
+
+### 2. 位置情報の取得フロー
+
+```mermaid
+graph TD
+    A[アプリ起動] --> B[位置情報許可確認]
+    B --> C{許可あり?}
+    C -->|Yes| D[getCurrentLocation]
+    C -->|No| E[エラー表示]
+    D --> F[watchPositionAsync開始]
+    F --> G[2秒/5m移動で更新]
+    G --> H[locationStore更新]
+    H --> I[地図更新判定]
+    I -->|追従ON| J[地図を自動移動]
+    I -->|追従OFF| K[地図は移動しない]
+```
+
+### 3. 主要コンポーネントの役割
+
+#### 3.1 useLocation Hook
+- **初期化**: アプリ起動時に位置情報の許可を確認し、監視を開始
+- **監視**: `Location.watchPositionAsync`で継続的に位置を監視
+- **更新条件**: 2秒経過 または 5m移動
+
+#### 3.2 location-store
+- **状態管理**: 現在位置、エラー、設定を保持
+- **永続化**: 設定（更新間隔、精度モード等）をMMKVで保存
+
+#### 3.3 useMapWithLocation Hook
+- **地図連携**: locationStoreの変更を監視し、追従モードON時に地図を更新
+- **追従制御**: ユーザーの操作に応じて追従ON/OFFを切り替え
+
+### 4. 位置情報更新の詳細
+
+**Location.watchPositionAsync の設定**
+```typescript
+{
+  accuracy: Location.Accuracy.High,  // 高精度（GPS使用）
+  timeInterval: 2000,                // 最小2秒間隔
+  distanceInterval: 5,               // 最小5m移動
+}
+```
+
+**実際の更新タイミング**
+- 2秒経過 AND 5m以上移動した場合に更新
+- どちらかの条件を満たしても、もう一方の条件も満たす必要がある
+
+### 5. 方向（heading）情報の独立更新
+
+**別途、高頻度で方向を更新**
+```typescript
+Location.watchHeadingAsync({
+  accuracy: 6,  // 6度の精度
+}, (heading) => {
+  // 100ms間隔で方向のみ更新
+})
+```
+
+## Supabase保存の実装案
+
+### 1. 移動距離の計算
+
+```typescript
+// 距離計算関数（Haversine formula）
+function calculateDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371e3; // 地球の半径（メートル）
+  const φ1 = lat1 * Math.PI/180;
+  const φ2 = lat2 * Math.PI/180;
+  const Δφ = (lat2-lat1) * Math.PI/180;
+  const Δλ = (lon2-lon1) * Math.PI/180;
+
+  const a = Math.sin(Δφ/2) * Math.sin(Δφ/2) +
+            Math.cos(φ1) * Math.cos(φ2) *
+            Math.sin(Δλ/2) * Math.sin(Δλ/2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+
+  return R * c; // メートル単位の距離
+}
+```
+
+### 2. Supabase保存の実装イメージ
+
+```typescript
+// location-store.ts に追加
+interface LocationState {
+  // ... 既存の状態
+  lastSavedLocation: UserLocationData | null;  // 最後に保存した位置
+}
+
+// アクション追加
+setCurrentLocation: (location) => set((state) => {
+  state.currentLocation = location;
+  
+  // 5m以上移動したらSupabaseに保存
+  if (state.lastSavedLocation) {
+    const distance = calculateDistance(
+      state.lastSavedLocation.coords.latitude,
+      state.lastSavedLocation.coords.longitude,
+      location.coords.latitude,
+      location.coords.longitude
+    );
+    
+    if (distance >= 5) {
+      // Supabaseに保存（非同期で実行）
+      saveLocationToSupabase(location);
+      state.lastSavedLocation = location;
+    }
+  } else {
+    // 初回は必ず保存
+    saveLocationToSupabase(location);
+    state.lastSavedLocation = location;
+  }
+});
+```
+
+### 3. Supabaseテーブル設計案(ここは DataModel.md も参考に考える必要がある)
+
+```sql
+-- user_locations テーブル
+CREATE TABLE user_locations (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) NOT NULL,
+  latitude DOUBLE PRECISION NOT NULL,
+  longitude DOUBLE PRECISION NOT NULL,
+  accuracy DOUBLE PRECISION,
+  heading DOUBLE PRECISION,
+  speed DOUBLE PRECISION,
+  altitude DOUBLE PRECISION,
+  recorded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- インデックス
+CREATE INDEX idx_user_locations_user_id ON user_locations(user_id);
+CREATE INDEX idx_user_locations_recorded_at ON user_locations(recorded_at);
+```
+
+### 4. 実装時の考慮事項
+
+1. **バッテリー消費**
+   - 高頻度の位置情報取得はバッテリーを消費
+   - バックグラウンドでの動作制限
+
+2. **ネットワーク通信**
+   - オフライン時の処理（キューイング）
+   - 通信エラーのリトライ処理
+
+3. **プライバシー**
+   - 位置情報の保存についてユーザーへの明示的な同意
+   - データの暗号化
+
+4. **最適化**
+   - バッチ処理（複数の位置情報をまとめて送信）
+   - 不要なデータの定期削除
+
+## 現在の設定値の妥当性
+
+- **2秒間隔**: 歩行速度（時速4km）で約2.2m移動。適切な更新頻度
+- **5m移動**: 小さな動きは無視し、意味のある移動のみ検出
+- **100ms方向更新**: スムーズな方向表示のために必要
+
+これらの設定は、バッテリー消費と精度のバランスが取れた値となっています。

--- a/src/features/home/presentation/HomeScreen.tsx
+++ b/src/features/home/presentation/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Text } from 'react-native';
 import MapView from 'react-native-maps';
 import AudioPlayerModal from '../../../../components/AudioPlayerModal';
 import { AudioPinMarkers } from '../../audioPin/presentation/components/AudioPinMarkers';
@@ -11,6 +11,8 @@ import { useLocation } from '../../location/presentation/hooks/useLocation';
 import { LocationButton } from '../../map/presentation/components/LocationButton';
 import { MapContainer } from '../../map/presentation/components/MapContainer';
 import { useMapRegion } from '../../map/presentation/hooks/useMapRegion';
+import { useMapWithLocation } from '../../map/presentation/hooks/useMapWithLocation';
+import { useMapFollowing } from '../../map/presentation/hooks/useMapFollowing';
 import { ErrorDisplay } from './components/ErrorDisplay';
 
 export default function HomeScreen() {
@@ -20,6 +22,8 @@ export default function HomeScreen() {
   const { location, errorMsg } = useLocation();
   const { audioPins, selectedAudio, modalVisible, handlePinPress, handleCloseModal } = useAudioPins();
   const { region, updateRegion } = useMapRegion();
+  const { centerOnUserLocation } = useMapWithLocation(mapRef);
+  const { isFollowingUser } = useMapFollowing();
   
   // 最後の有効な位置情報を保持（チカチカ防止）
   const [stableLocation, setStableLocation] = useState(location);
@@ -43,21 +47,6 @@ export default function HomeScreen() {
     pins: audioPins,
     selectedLayerIds: getSelectedLayerIds(),
   });
-
-  // 現在位置を中心に戻すハンドラー
-  const centerOnUserLocation = () => {
-    if (stableLocation && mapRef.current) {
-      const newRegion = {
-        latitude: stableLocation.coords.latitude,
-        longitude: stableLocation.coords.longitude,
-        latitudeDelta: region.latitudeDelta,
-        longitudeDelta: region.longitudeDelta,
-      };
-      
-      mapRef.current.animateToRegion(newRegion, 1000);
-      updateRegion(newRegion);
-    }
-  };
 
   return (
     <View style={styles.container}>
@@ -83,6 +72,15 @@ export default function HomeScreen() {
         disabled={!stableLocation}
       />
 
+      {/* デバッグ用：追従状態の表示 */}
+      {__DEV__ && (
+        <View style={styles.debugInfo}>
+          <Text style={styles.debugText}>
+            追従: {isFollowingUser ? 'ON' : 'OFF'}
+          </Text>
+        </View>
+      )}
+
       <ErrorDisplay errorMsg={errorMsg} />
 
       {/* 音声再生モーダル */}
@@ -98,5 +96,18 @@ export default function HomeScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  debugInfo: {
+    position: 'absolute',
+    top: 100,
+    right: 20,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    padding: 10,
+    borderRadius: 5,
+  },
+  debugText: {
+    color: 'white',
+    fontSize: 14,
+    fontWeight: 'bold',
   },
 }); 

--- a/src/features/location/application/location-store.ts
+++ b/src/features/location/application/location-store.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 import { devtools, persist, subscribeWithSelector } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
-import { UserLocationData, LocationError } from '../domain/entities/Location';
 import { storage } from '../../../shared/infra/storage/mmkvStorage';
+import { LocationError, UserLocationData } from '../domain/entities/Location';
 
 /**
  * 位置情報状態の型定義

--- a/src/features/map/application/map-store.ts
+++ b/src/features/map/application/map-store.ts
@@ -1,9 +1,9 @@
+import { MMKV } from 'react-native-mmkv';
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
-import { MMKV } from 'react-native-mmkv';
-import { MapRegion } from '../domain/entities/MapRegion';
 import { StorageKeys } from '../../../constants/StorageKeys';
+import { MapRegion } from '../domain/entities/MapRegion';
 
 /**
  * 地図関連の状態管理
@@ -97,9 +97,9 @@ export const useMapStore = create<MapState>()(
         
         setIsFollowingUser: (isFollowing) => set((state) => {
           state.isFollowingUser = isFollowing;
-          if (__DEV__) {
-            console.log(`[MapStore] 追従モード: ${isFollowing ? 'ON' : 'OFF'}`);
-          }
+          // if (__DEV__) {
+          //   console.log(`[MapStore] 追従モード: ${isFollowing ? 'ON' : 'OFF'}`);
+          // }
         }),
         
         updateMapType: (mapType) => set((state) => {

--- a/src/features/map/application/map-store.ts
+++ b/src/features/map/application/map-store.ts
@@ -1,0 +1,139 @@
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+import { MMKV } from 'react-native-mmkv';
+import { MapRegion } from '../domain/entities/MapRegion';
+import { StorageKeys } from '../../../constants/StorageKeys';
+
+/**
+ * 地図関連の状態管理
+ * StateManagement.mdの規約に基づいて実装
+ */
+
+// MMKVインスタンス
+const storage = new MMKV();
+
+// ストレージアダプター（StorageValue型に対応）
+const mmkvStorage = {
+  getItem: (name: string) => {
+    const value = storage.getString(name);
+    return value ? JSON.parse(value) : null;
+  },
+  setItem: (name: string, value: unknown) => {
+    storage.set(name, JSON.stringify(value));
+  },
+  removeItem: (name: string) => storage.delete(name),
+};
+
+// 地図タイプの定義
+export type MapType = 'standard' | 'satellite' | 'hybrid';
+
+// UI状態と設定の型定義
+interface MapState {
+  // UI状態（非永続化）
+  region: MapRegion;
+  zoomLevel: number;
+  isFollowingUser: boolean; // ユーザー位置に追従中かどうか
+  
+  // 設定（永続化対象）
+  settings: {
+    mapType: MapType;
+    showUserLocation: boolean;
+    showCompass: boolean;
+    showScale: boolean;
+    defaultZoomLevel: number;
+  };
+  
+  // アクション
+  updateRegion: (region: MapRegion) => void;
+  updateZoomLevel: (zoomLevel: number) => void;
+  setIsFollowingUser: (isFollowing: boolean) => void;
+  updateMapType: (mapType: MapType) => void;
+  updateSettings: (settings: Partial<MapState['settings']>) => void;
+  resetToDefaults: () => void;
+}
+
+// 永続化する部分の型定義
+type PersistedState = {
+  settings: MapState['settings'];
+};
+
+// 初期値
+const initialState = {
+  region: {
+    latitude: 35.0116, // 京都を初期表示
+    longitude: 135.7681,
+    latitudeDelta: 0.05,
+    longitudeDelta: 0.05,
+  },
+  zoomLevel: 15, // おおよそのズームレベル
+  isFollowingUser: false,
+  settings: {
+    mapType: 'standard' as MapType,
+    showUserLocation: true,
+    showCompass: true,
+    showScale: true,
+    defaultZoomLevel: 15,
+  },
+};
+
+export const useMapStore = create<MapState>()(
+  devtools(
+    persist(
+      immer((set) => ({
+        ...initialState,
+        
+        updateRegion: (region) => set((state) => {
+          state.region = region;
+          // regionから概算のズームレベルを計算
+          // deltaが小さいほどズームレベルが高い
+          const avgDelta = (region.latitudeDelta + region.longitudeDelta) / 2;
+          state.zoomLevel = Math.round(Math.log2(360 / avgDelta));
+        }),
+        
+        updateZoomLevel: (zoomLevel) => set((state) => {
+          state.zoomLevel = zoomLevel;
+        }),
+        
+        setIsFollowingUser: (isFollowing) => set((state) => {
+          state.isFollowingUser = isFollowing;
+          if (__DEV__) {
+            console.log(`[MapStore] 追従モード: ${isFollowing ? 'ON' : 'OFF'}`);
+          }
+        }),
+        
+        updateMapType: (mapType) => set((state) => {
+          state.settings.mapType = mapType;
+        }),
+        
+        updateSettings: (settings) => set((state) => {
+          state.settings = { ...state.settings, ...settings };
+        }),
+        
+        resetToDefaults: () => set(() => ({
+          ...initialState,
+        })),
+      })),
+      {
+        name: StorageKeys.MAP.SETTINGS,
+        storage: mmkvStorage,
+        partialize: (state) => ({
+          settings: state.settings,
+        }) as MapState,
+      }
+    ),
+    {
+      name: 'map-store',
+    }
+  )
+);
+
+// セレクターヘルパー関数
+export const mapSelectors = {
+  region: (state: MapState) => state.region,
+  zoomLevel: (state: MapState) => state.zoomLevel,
+  isFollowingUser: (state: MapState) => state.isFollowingUser,
+  settings: (state: MapState) => state.settings,
+  mapType: (state: MapState) => state.settings.mapType,
+  showUserLocation: (state: MapState) => state.settings.showUserLocation,
+};

--- a/src/features/map/presentation/components/MapContainer.tsx
+++ b/src/features/map/presentation/components/MapContainer.tsx
@@ -4,6 +4,8 @@ import MapView, { Marker } from 'react-native-maps';
 import Svg, { Circle, Path } from 'react-native-svg';
 import { UserLocationData } from '../../../location/domain/entities/Location';
 import { MapRegion } from '../../domain/entities/MapRegion';
+import { useMapFollowing } from '../hooks/useMapFollowing';
+import { useMapSettings } from '../hooks/useMapSettings';
 
 interface MapContainerProps {
   region: MapRegion;
@@ -14,17 +16,44 @@ interface MapContainerProps {
 
 export const MapContainer = forwardRef<MapView, MapContainerProps>(
   ({ region, onRegionChange, userLocation, children }, ref) => {
+    // // デバッグ用：位置情報の変化を監視
+    // React.useEffect(() => {
+    //   if (userLocation?.coords) {
+    //     console.log('Location update:', {
+    //       lat: userLocation.coords.latitude,
+    //       lng: userLocation.coords.longitude,
+    //       heading: userLocation.coords.heading,
+    //     });
+    //   }
+    // }, [userLocation]);
+    
+    const { mapType, showCompass, showScale } = useMapSettings();
+    const { stopFollowing } = useMapFollowing();
+
+    const handleRegionChange = (newRegion: MapRegion) => {
+      // ユーザーが地図を動かしたら追従を停止
+      stopFollowing();
+      onRegionChange(newRegion);
+      
+      if (__DEV__) {
+        console.log(`[MapContainer] 地図手動操作（追従停止）:`, {
+          lat: newRegion.latitude.toFixed(6),
+          lng: newRegion.longitude.toFixed(6),
+        });
+      }
+    };
+
     return (
       <MapView
         ref={ref}
         style={styles.map}
         region={region}
-        onRegionChangeComplete={onRegionChange}
+        onRegionChangeComplete={handleRegionChange}
         showsUserLocation={false}
         showsMyLocationButton={false}
-        showsCompass={true}
-        showsScale={true}
-        mapType="standard"
+        showsCompass={showCompass}
+        showsScale={showScale}
+        mapType={mapType}
         followsUserLocation={false}
         userLocationAnnotationTitle="現在位置"
         userLocationCalloutEnabled={true}

--- a/src/features/map/presentation/components/MapContainer.tsx
+++ b/src/features/map/presentation/components/MapContainer.tsx
@@ -35,12 +35,12 @@ export const MapContainer = forwardRef<MapView, MapContainerProps>(
       stopFollowing();
       onRegionChange(newRegion);
       
-      if (__DEV__) {
-        console.log(`[MapContainer] 地図手動操作（追従停止）:`, {
-          lat: newRegion.latitude.toFixed(6),
-          lng: newRegion.longitude.toFixed(6),
-        });
-      }
+      // if (__DEV__) {
+      //   console.log(`[MapContainer] 地図手動操作（追従停止）:`, {
+      //     lat: newRegion.latitude.toFixed(6),
+      //     lng: newRegion.longitude.toFixed(6),
+      //   });
+      // }
     };
 
     return (

--- a/src/features/map/presentation/hooks/useMapFollowing.ts
+++ b/src/features/map/presentation/hooks/useMapFollowing.ts
@@ -1,0 +1,21 @@
+import { useMapStore } from '../../application/map-store';
+
+/**
+ * 地図のユーザー位置追従管理フック
+ * ユーザーの現在位置への自動追従機能を管理
+ */
+export const useMapFollowing = () => {
+  const isFollowingUser = useMapStore((state) => state.isFollowingUser);
+  const setIsFollowingUser = useMapStore((state) => state.setIsFollowingUser);
+
+  const startFollowing = () => setIsFollowingUser(true);
+  const stopFollowing = () => setIsFollowingUser(false);
+  const toggleFollowing = () => setIsFollowingUser(!isFollowingUser);
+
+  return {
+    isFollowingUser,
+    startFollowing,
+    stopFollowing,
+    toggleFollowing,
+  };
+};

--- a/src/features/map/presentation/hooks/useMapRegion.ts
+++ b/src/features/map/presentation/hooks/useMapRegion.ts
@@ -1,17 +1,12 @@
-import { useState } from 'react';
-import { MapRegion } from '../../domain/entities/MapRegion';
+import { useMapStore } from '../../application/map-store';
 
+/**
+ * 地図のリージョン管理フック
+ * 既存のインターフェースを維持しながら、内部でZustandストアを使用
+ */
 export const useMapRegion = () => {
-  const [region, setRegion] = useState<MapRegion>({
-    latitude: 35.0116, // 京都を初期表示
-    longitude: 135.7681,
-    latitudeDelta: 0.05,
-    longitudeDelta: 0.05,
-  });
-
-  const updateRegion = (newRegion: MapRegion) => {
-    setRegion(newRegion);
-  };
+  const region = useMapStore((state) => state.region);
+  const updateRegion = useMapStore((state) => state.updateRegion);
 
   return {
     region,

--- a/src/features/map/presentation/hooks/useMapSettings.ts
+++ b/src/features/map/presentation/hooks/useMapSettings.ts
@@ -1,0 +1,23 @@
+import { useMapStore, mapSelectors } from '../../application/map-store';
+
+/**
+ * 地図の設定管理フック
+ * mapType、表示オプションなどの設定を管理
+ */
+export const useMapSettings = () => {
+  const settings = useMapStore(mapSelectors.settings);
+  const updateMapType = useMapStore((state) => state.updateMapType);
+  const updateSettings = useMapStore((state) => state.updateSettings);
+  const resetToDefaults = useMapStore((state) => state.resetToDefaults);
+
+  return {
+    settings,
+    mapType: settings.mapType,
+    showUserLocation: settings.showUserLocation,
+    showCompass: settings.showCompass,
+    showScale: settings.showScale,
+    updateMapType,
+    updateSettings,
+    resetToDefaults,
+  };
+};

--- a/src/features/map/presentation/hooks/useMapWithLocation.ts
+++ b/src/features/map/presentation/hooks/useMapWithLocation.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from 'react';
+import MapView from 'react-native-maps';
+import { useMapStore } from '../../application/map-store';
+import { useLocationStore } from '../../../location/application/location-store';
+import { UserLocationData } from '../../../location/domain/entities/Location';
+
+/**
+ * 地図と位置情報の連携フック
+ * 位置情報の更新に応じて地図を自動的に追従させる
+ */
+export const useMapWithLocation = (mapRef: React.RefObject<MapView | null>) => {
+  const region = useMapStore((state) => state.region);
+  const updateRegion = useMapStore((state) => state.updateRegion);
+  const isFollowingUser = useMapStore((state) => state.isFollowingUser);
+  const setIsFollowingUser = useMapStore((state) => state.setIsFollowingUser);
+  
+  const currentLocation = useLocationStore((state) => state.currentLocation);
+  const previousLocationRef = useRef<UserLocationData | null>(null);
+  
+  // 位置情報が更新された時の処理
+  useEffect(() => {
+    if (!currentLocation || !isFollowingUser || !mapRef.current) {
+      return;
+    }
+    
+    // 位置が変わった場合のみ地図を更新
+    const prevLocation = previousLocationRef.current;
+    if (
+      !prevLocation ||
+      prevLocation.coords.latitude !== currentLocation.coords.latitude ||
+      prevLocation.coords.longitude !== currentLocation.coords.longitude
+    ) {
+      const newRegion = {
+        latitude: currentLocation.coords.latitude,
+        longitude: currentLocation.coords.longitude,
+        latitudeDelta: region.latitudeDelta,
+        longitudeDelta: region.longitudeDelta,
+      };
+      
+      // アニメーション付きで地図を移動
+      mapRef.current.animateToRegion(newRegion, 1000);
+      updateRegion(newRegion);
+      
+      if (__DEV__) {
+        console.log(`[MapWithLocation] 位置更新による地図追従:`, {
+          lat: newRegion.latitude.toFixed(6),
+          lng: newRegion.longitude.toFixed(6),
+        });
+      }
+      
+      previousLocationRef.current = currentLocation;
+    }
+  }, [currentLocation, isFollowingUser, region.latitudeDelta, region.longitudeDelta, updateRegion, mapRef]);
+  
+  // 現在位置に移動する関数
+  const centerOnUserLocation = () => {
+    if (currentLocation && mapRef.current) {
+      const newRegion = {
+        latitude: currentLocation.coords.latitude,
+        longitude: currentLocation.coords.longitude,
+        latitudeDelta: region.latitudeDelta,
+        longitudeDelta: region.longitudeDelta,
+      };
+      
+      mapRef.current.animateToRegion(newRegion, 1000);
+      updateRegion(newRegion);
+      setIsFollowingUser(true);
+      
+      if (__DEV__) {
+        console.log(`[MapWithLocation] 現在位置ボタンタップ:`, {
+          lat: newRegion.latitude.toFixed(6),
+          lng: newRegion.longitude.toFixed(6),
+        });
+      }
+    }
+  };
+  
+  return {
+    centerOnUserLocation,
+    isFollowingUser,
+  };
+};

--- a/src/features/map/presentation/hooks/useMapWithLocation.ts
+++ b/src/features/map/presentation/hooks/useMapWithLocation.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 import MapView from 'react-native-maps';
-import { useMapStore } from '../../application/map-store';
 import { useLocationStore } from '../../../location/application/location-store';
 import { UserLocationData } from '../../../location/domain/entities/Location';
+import { useMapStore } from '../../application/map-store';
 
 /**
  * 地図と位置情報の連携フック
@@ -41,12 +41,12 @@ export const useMapWithLocation = (mapRef: React.RefObject<MapView | null>) => {
       mapRef.current.animateToRegion(newRegion, 1000);
       updateRegion(newRegion);
       
-      if (__DEV__) {
-        console.log(`[MapWithLocation] 位置更新による地図追従:`, {
-          lat: newRegion.latitude.toFixed(6),
-          lng: newRegion.longitude.toFixed(6),
-        });
-      }
+      // if (__DEV__) {
+      //   console.log(`[MapWithLocation] 位置更新による地図追従:`, {
+      //     lat: newRegion.latitude.toFixed(6),
+      //     lng: newRegion.longitude.toFixed(6),
+      //   });
+      // }
       
       previousLocationRef.current = currentLocation;
     }
@@ -66,12 +66,12 @@ export const useMapWithLocation = (mapRef: React.RefObject<MapView | null>) => {
       updateRegion(newRegion);
       setIsFollowingUser(true);
       
-      if (__DEV__) {
-        console.log(`[MapWithLocation] 現在位置ボタンタップ:`, {
-          lat: newRegion.latitude.toFixed(6),
-          lng: newRegion.longitude.toFixed(6),
-        });
-      }
+      // if (__DEV__) {
+      //   console.log(`[MapWithLocation] 現在位置ボタンタップ:`, {
+      //     lat: newRegion.latitude.toFixed(6),
+      //     lng: newRegion.longitude.toFixed(6),
+      //   });
+      // }
     }
   };
   


### PR DESCRIPTION
## [2025-07-24] Map機能の状態管理移行

### 概要
map機能をStateManagement.mdの規約に基づいて、Zustand + MMKV + TanStack Query（準備）のアーキテクチャに移行しました。

### 追加ファイル
1. **src/features/map/application/map-store.ts**
   - UI状態（region、zoomLevel、isFollowingUser）の管理
   - 設定（mapType、表示オプション）の管理
   - MMKV による設定の永続化

2. **src/features/map/presentation/hooks/useMapSettings.ts**
   - 地図設定（mapType、コンパス、スケール表示）の管理フック

3. **src/features/map/presentation/hooks/useMapFollowing.ts**
   - ユーザー位置追従機能の管理フック

4. **src/features/map/presentation/hooks/useMapWithLocation.ts**
   - locationストアとの連携フック
   - 位置情報更新時の自動追従機能

5. **src/features/map/application/map-store.test.ts**
   - Zustandストアのユニットテスト

### 変更ファイル
1. **src/features/map/presentation/hooks/useMapRegion.ts**
   - 内部実装をZustandストアに変更（インターフェースは維持）

2. **src/features/map/presentation/components/MapContainer.tsx**
   - 地図設定をストアから取得するよう変更
   - ユーザーが地図を操作した際の追従停止機能を追加

3. **src/features/home/presentation/HomeScreen.tsx**
   - useMapWithLocation フックを使用して位置追従機能を統合
   - デバッグ用の追従状態表示を追加（開発環境のみ）

### 新機能
1. **ユーザー位置追従機能**
   - 現在位置ボタンタップで追従開始
   - 地図を手動操作すると追従停止
   - 位置情報更新時に地図が自動的に追従

2. **地図タイプの動的切り替え**
   - standard / satellite / hybrid の切り替えが可能に

3. **設定の永続化**
   - 地図タイプ、表示オプションがアプリ再起動後も保持される

### デバッグ機能（開発環境のみ）
1. **画面表示**
   - 画面右上に「追従: ON/OFF」の状態表示

2. **コンソールログ**
   ```
   [MapStore] 追従モード: ON/OFF
   [MapWithLocation] 現在位置ボタンタップ: { lat, lng }
   [MapWithLocation] 位置更新による地図追従: { lat, lng }
   [MapContainer] 地図手動操作（追従停止）: { lat, lng }
   ```

### テスト方法
1. **追従機能の確認**
   - 現在位置ボタンをタップ → 追従ONになることを確認
   - 地図をドラッグ → 追従OFFになることを確認
   - 再度現在位置ボタンをタップ → 追従ONに戻ることを確認

2. **永続化の確認**
   - アプリを完全終了して再起動
   - 地図設定が保持されていることを確認

### 技術的な改善点
- グローバル状態管理により、コンポーネント間での状態共有が容易に
- 設定の永続化により、ユーザー体験が向上
- locationストアとの適切な連携により、機能間の結合度が低減
- テスタビリティの向上（ユニットテスト実装）

### 次のステップ
- audioPin機能の状態管理移行（Phase 4）
- 統合テストと最終調整
